### PR TITLE
Satchelize ros filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   tf2
   tf2_geometry_msgs
-  tf2_ros)
+  tf2_ros
+  burro_core_ros)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(YAML_CPP yaml-cpp)

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -542,7 +542,7 @@ template<class T> class RosFilter
     std::vector<std::string> stateVariableNames_;
 
     //! @brief Vector to hold our subscribers until they go out of scope
-    //!
+    //! test help doc: https://personalrobotics.cs.washington.edu/software/unit-testing/
     std::vector<std::shared_ptr<message_filters::SubscriberBase>> topicSubs_;
 
     //! @brief This object accumulates dynamic diagnostics, e.g., diagnostics relating

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -36,6 +36,7 @@
 #include "robot_localization/ros_filter_utilities.h"
 #include "robot_localization/filter_common.h"
 #include "robot_localization/filter_base.h"
+#include "burro_core_ros/ros/message_filters.h"
 
 #include <robot_localization/SetPose.h>
 #include <robot_localization/ToggleFilterProcessing.h>

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -543,7 +543,7 @@ template<class T> class RosFilter
 
     //! @brief Vector to hold our subscribers until they go out of scope
     //!
-    std::vector<ros::Subscriber> topicSubs_;
+    std::vector<std::shared_ptr<message_filters::SubscriberBase>> topicSubs_;
 
     //! @brief This object accumulates dynamic diagnostics, e.g., diagnostics relating
     //! to sensor data.

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
+  <depend>burro_core_ros</depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1103,14 +1103,12 @@ namespace RobotLocalization
         // Store the odometry topic subscribers so they don't go out of scope.
         if (poseUpdateSum + twistUpdateSum > 0)
         {
-          // topicSubs_.push_back(
-          //   nh_.subscribe<nav_msgs::Odometry>(odomTopic, odomQueueSize,
-          //     boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
-          //     ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
-              burro::FilterSubscriber<nav_msgs::Odometry> odometrySubscriber;
-              odometrySubscriber.subscribe(nh_, odomTopic, odomQueueSize, ros::TransportHints().tcpNoDelay(nodelayOdom));
-              odometrySubscriber.registerCallback(boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData));
-        }
+              auto odometrySubscriber = std::make_shared<burro::FilterSubscriber<nav_msgs::Odometry>>();
+              odometrySubscriber->subscribe(nh_, odomTopic, odomQueueSize, ros::TransportHints().tcpNoDelay(nodelayOdom));
+              odometrySubscriber->registerCallback(boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData));
+              topicSubs_.push_back(odometrySubscriber);
+
+            }
         else
         {
           std::stringstream stream;
@@ -1223,10 +1221,10 @@ namespace RobotLocalization
           const CallbackData callbackData(poseTopicName, poseUpdateVec, poseUpdateSum, differential, relative,
             poseMahalanobisThresh);
 
-          topicSubs_.push_back(
-            nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic, poseQueueSize,
-              boost::bind(&RosFilter::poseCallback, this, _1, callbackData, worldFrameId_, false),
-              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
+          auto poseStampedSubscriber = std::make_shared<burro::FilterSubscriber<geometry_msgs::PoseWithCovarianceStamped>>();
+          poseStampedSubscriber->subscribe(nh_, poseTopic, poseQueueSize, ros::TransportHints().tcpNoDelay(nodelayPose));
+          poseStampedSubscriber->registerCallback(boost::bind(&RosFilter::poseCallback, this, _1, callbackData, worldFrameId_, false));
+          topicSubs_.push_back(poseStampedSubscriber);
 
           if (differential)
           {
@@ -1300,10 +1298,11 @@ namespace RobotLocalization
           const CallbackData callbackData(twistTopicName, twistUpdateVec, twistUpdateSum, false, false,
             twistMahalanobisThresh);
 
-          topicSubs_.push_back(
-            nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic, twistQueueSize,
-              boost::bind(&RosFilter<T>::twistCallback, this, _1, callbackData, baseLinkFrameId_),
-              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
+
+          auto TwistSubscriber = std::make_shared<burro::FilterSubscriber<geometry_msgs::TwistWithCovarianceStamped>>();
+          TwistSubscriber->subscribe(nh_, twistTopic, twistQueueSize, ros::TransportHints().tcpNoDelay(nodelayTwist));
+          TwistSubscriber->registerCallback(boost::bind(&RosFilter<T>::twistCallback, this, _1, callbackData, baseLinkFrameId_));
+          topicSubs_.push_back(TwistSubscriber);
 
           twistVarCounts[StateMemberVx] += twistUpdateVec[StateMemberVx];
           twistVarCounts[StateMemberVy] += twistUpdateVec[StateMemberVy];
@@ -1470,14 +1469,12 @@ namespace RobotLocalization
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
             differential, relative, accelMahalanobisThresh);
 
-          // topicSubs_.push_back(
-          //   nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
-          //     boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
-          //       accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
-          burro::FilterSubscriber<sensor_msgs::Imu> ImuSubscriber;
-          ImuSubscriber.subscribe(nh_, imuTopic, imuQueueSize, ros::TransportHints().tcpNoDelay(nodelayImu));
-          ImuSubscriber.registerCallback(boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
+          auto ImuSubscriber = std::make_shared<burro::FilterSubscriber<sensor_msgs::Imu>>();
+          ImuSubscriber->subscribe(nh_, imuTopic, imuQueueSize, ros::TransportHints().tcpNoDelay(nodelayImu));
+          ImuSubscriber->registerCallback(boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
             accelCallbackData));
+
+          topicSubs_.push_back(ImuSubscriber);
         }
         else
         {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1103,10 +1103,13 @@ namespace RobotLocalization
         // Store the odometry topic subscribers so they don't go out of scope.
         if (poseUpdateSum + twistUpdateSum > 0)
         {
-          topicSubs_.push_back(
-            nh_.subscribe<nav_msgs::Odometry>(odomTopic, odomQueueSize,
-              boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
-              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
+          // topicSubs_.push_back(
+          //   nh_.subscribe<nav_msgs::Odometry>(odomTopic, odomQueueSize,
+          //     boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
+          //     ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
+              burro::FilterSubscriber<nav_msgs::Odometry> odometrySubscriber;
+              odometrySubscriber.subscribe(nh_, odomTopic, odomQueueSize, ros::TransportHints().tcpNoDelay(nodelayOdom));
+              odometrySubscriber.registerCallback(boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData));
         }
         else
         {
@@ -1467,10 +1470,14 @@ namespace RobotLocalization
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
             differential, relative, accelMahalanobisThresh);
 
-          topicSubs_.push_back(
-            nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
-              boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
-                accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
+          // topicSubs_.push_back(
+          //   nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
+          //     boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
+          //       accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
+          burro::FilterSubscriber<sensor_msgs::Imu> ImuSubscriber;
+          ImuSubscriber.subscribe(nh_, imuTopic, imuQueueSize, ros::TransportHints().tcpNoDelay(nodelayImu));
+          ImuSubscriber.registerCallback(boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
+            accelCallbackData));
         }
         else
         {


### PR DESCRIPTION
The PR replaces the generic ros subscribers with burro monitorsubscriber which has the access to the callbacks to make it work with Satchel.

https://personalrobotics.cs.washington.edu/software/unit-testing/

The PR passes the unit tests of robot_localization package


```
[==========] Running 10 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 10 tests from InterfacesTest
[ RUN      ] InterfacesTest.OdomPoseBasicIO
[       OK ] InterfacesTest.OdomPoseBasicIO (1235 ms)
[ RUN      ] InterfacesTest.OdomTwistBasicIO
[       OK ] InterfacesTest.OdomTwistBasicIO (55332 ms)
[ RUN      ] InterfacesTest.PoseBasicIO
[       OK ] InterfacesTest.PoseBasicIO (1189 ms)
[ RUN      ] InterfacesTest.TwistBasicIO
[       OK ] InterfacesTest.TwistBasicIO (55344 ms)
[ RUN      ] InterfacesTest.ImuPoseBasicIO
[       OK ] InterfacesTest.ImuPoseBasicIO (2282 ms)
[ RUN      ] InterfacesTest.ImuTwistBasicIO
[       OK ] InterfacesTest.ImuTwistBasicIO (4306 ms)
[ RUN      ] InterfacesTest.ImuAccBasicIO
[       OK ] InterfacesTest.ImuAccBasicIO (3211 ms)
[ RUN      ] InterfacesTest.OdomDifferentialIO
[       OK ] InterfacesTest.OdomDifferentialIO (6214 ms)
[ RUN      ] InterfacesTest.PoseDifferentialIO
[       OK ] InterfacesTest.PoseDifferentialIO (6218 ms)
[ RUN      ] InterfacesTest.ImuDifferentialIO
[       OK ] InterfacesTest.ImuDifferentialIO (12228 ms)
[----------] 10 tests from InterfacesTest (147560 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test suite ran. (147560 ms total)
[  PASSED  ] 10 tests.

```

```
[Testcase: testtest_ukf_localization_node_bag1_pose] ... ok

[ROSTEST]-----------------------------------------------------------------------

[robot_localization.rosunit-test_ukf_localization_node_bag1_pose/PoseCheck][passed]

SUMMARY
 * RESULT: SUCCESS
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 0

rostest log file is in /home/chun/.ros/log/159510_03-25-25_10-49-25/rostest-chun-XPS-15-9510-672178.log

```
